### PR TITLE
fix: (snow leaderboard) add s3 prefix optionally read from env var

### DIFF
--- a/snow_leaderboard/README.md
+++ b/snow_leaderboard/README.md
@@ -17,6 +17,7 @@ This project is in Python and is built using Poetry.
     look like this:
     ```sh
     S3_BUCKET = <my bucket>
+    S3_PREFIX = <dir inside bucket>
     ```
 7.  Run `poetry install --sync` to install the dependencies for this project,
     including development and testing dependencies, into a virtual environment

--- a/snow_leaderboard/src/etl/paths.py
+++ b/snow_leaderboard/src/etl/paths.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 DATA_DIR = Path(__file__).parent.parent.parent / "data"
 
+S3_KEY_PREFIX = os.getenv("S3_PREFIX", None)
+
 LOCATIONS = "ski_locations"
 SNOWFALL = "snowfall"
 
@@ -30,7 +32,10 @@ def get_local_dir_for_location_data() -> Path:
 
 
 def get_bucket_and_key_for_location_data() -> tuple[str, str]:
-    key = f"{LOCATIONS}/ski_areas_all.parquet"
+    if S3_KEY_PREFIX is None:
+        key = f"{LOCATIONS}/ski_areas_all.parquet"
+    else:
+        key = f"{S3_KEY_PREFIX}/{LOCATIONS}/ski_areas_all.parquet"
     return get_bucket(), key
 
 
@@ -57,7 +62,10 @@ def get_local_dir_for_tiffs() -> Path:
 
 
 def get_bucket_and_key_for_tiffs() -> tuple[str, str]:
-    key = f"{SNOWFALL}/{TIFFS}"
+    if S3_KEY_PREFIX is None:
+        key = f"{SNOWFALL}/{TIFFS}"
+    else:
+        key = f"{S3_KEY_PREFIX}/{SNOWFALL}/{TIFFS}"
     return get_bucket(), key
 
 
@@ -79,8 +87,12 @@ def get_bucket_and_key_for_daily_pq_season_dir(
         raise TypeError("Must set either partition or season")
     elif partition is not None and season is not None:
         raise TypeError("Must set only one of partition or season")
-    key = season or get_season_of_partition(partition=partition)  # type: ignore
-    return get_bucket(), f"{SNOWFALL}/{DAILY_PQ}/{key}"
+    season_dir = season or get_season_of_partition(partition=partition)  # type: ignore
+    if S3_KEY_PREFIX is None:
+        key = f"{SNOWFALL}/{DAILY_PQ}/{season_dir}"
+    else:
+        key = f"{S3_KEY_PREFIX}/{SNOWFALL}/{DAILY_PQ}/{season_dir}"
+    return get_bucket(), key
 
 
 def get_bucket_and_key_for_daily_pq(partition: date) -> tuple[str, str]:
@@ -93,4 +105,8 @@ def get_bucket_and_key_for_daily_pq(partition: date) -> tuple[str, str]:
 
 
 def get_bucket_and_key_for_season_pq(season: int) -> tuple[str, str]:
-    return get_bucket(), f"{SNOWFALL}/{SEASON_PQ}/{season}.parquet"
+    if S3_KEY_PREFIX is None:
+        key = f"{SNOWFALL}/{SEASON_PQ}/{season}.parquet"
+    else:
+        key = f"{S3_KEY_PREFIX}/{SNOWFALL}/{SEASON_PQ}/{season}.parquet"
+    return get_bucket(), key

--- a/snow_leaderboard/src/viz/dsb_snowleaderboard.yml
+++ b/snow_leaderboard/src/viz/dsb_snowleaderboard.yml
@@ -3,7 +3,7 @@ grn: dsb:0uGUI4BUHtixsyvZ
 name: Snow Leaderboard
 description: "There are 661 ski areas in the Lower 48 -- which ones get the most snow?\n
   \nData provided by the National Weather Service's National Gridded Snowfall Analysis.
-  Last updated 2023-11-10T12:00:00+00:00.\n\"Observed At\" dates represent the 24-hour
+  Last updated 2023-11-13T12:00:00+00:00.\n\"Observed At\" dates represent the 24-hour
   period preceding 12:00:00 UTC on that date."
 type: dashboard
 globalFilters: []


### PR DESCRIPTION
For the snow leaderboard project, this PR allows you to configure the keys used in an S3 bucket to include a prefix. You can configure the prefix using an environment variable, `S3_PREFIX`. The prefix could be a directory or nested directories, separated with a `/`. For example:
`S3_BUCKET` = `foo`
`S3_PREFIX` = `bar/baz`
Would result in the S3 URI: `s3://foo/bar/baz/snowfall/season_pq/2023.parquet` for the 2023 season data file.

If `S3_PREFIX` is not specified, the URI would be: `s3://foo/snowfall/season_pq/2023.parquet` 