### PR TITLE
fix: use tmpdir for hashboard pulls

### DIFF
--- a/snow_leaderboard/src/etl/load_hashboard.py
+++ b/snow_leaderboard/src/etl/load_hashboard.py
@@ -11,18 +11,17 @@ from etl.paths import (
     get_bucket_and_key_for_season_pq,
 )
 
-VIZ_DIRECTORY = Path(__file__).parent.parent / "viz"
-
 
 @flow
 def load_season_to_hashboard(season: int) -> None:
     logger = get_run_logger()
     logger.info("Loading season %s to Hashboard", season)
     bucket, key = get_bucket_and_key_for_season_pq(season)
-    subprocess.run(["hb", "pull", "--all"])
-    yaml = YAML(typ="rt")
-    model = yaml.load(VIZ_DIRECTORY / "m_snowfall.yml")
-    model_id = model["grn"]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        subprocess.run(["hb", "pull", "--all"], cwd=tmpdir)
+        yaml = YAML(typ="rt")
+        model = yaml.load(Path(tmpdir) / "m_snowfall.yml")
+        model_id = model["grn"]
     with tempfile.TemporaryDirectory() as tmpdir:
         local_path = download_file_from_s3(bucket, key, Path(tmpdir)).resolve()
         subprocess.run(["hb", "upload", str(local_path)])


### PR DESCRIPTION
This PR changes the behavior of two steps in the Snow Leaderboard ETL to use a temp directory instead of a project directory for temporarily storing config files pulled from Hashboard.