### PR TITLE
Remove `main` schema from Hashquery examples

### DIFF
--- a/hashquery/m_campaigns.yml
+++ b/hashquery/m_campaigns.yml
@@ -6,7 +6,6 @@ description: This model provides details about each marketing campaign.
 source:
   connectionName: Uploads
   physicalName: campaigns.parquet
-  schema: main
 cols:
   - id: campaign_id
     type: attribute

--- a/hashquery/m_customers.yml
+++ b/hashquery/m_customers.yml
@@ -6,7 +6,6 @@ description: This table contains customer information.
 source:
   connectionName: Uploads
   physicalName: customers.parquet
-  schema: main
 cols:
   - id: id
     type: attribute

--- a/hashquery/m_orders.yml
+++ b/hashquery/m_orders.yml
@@ -6,7 +6,6 @@ description: order information
 source:
   connectionName: Uploads
   physicalName: orders.parquet
-  schema: main
 cols:
   - id: id
     type: attribute

--- a/hashquery/m_products.yml
+++ b/hashquery/m_products.yml
@@ -6,7 +6,6 @@ description: order information
 source:
   connectionName: Uploads
   physicalName: products.parquet
-  schema: main
 cols:
   - id: id
     type: attribute

--- a/hashquery/m_sales.yml
+++ b/hashquery/m_sales.yml
@@ -6,7 +6,6 @@ description: sales has a record for each customer, order, product combination
 source:
   connectionName: Uploads
   physicalName: sales.parquet
-  schema: main
 cols:
   - id: item_id
     type: attribute


### PR DESCRIPTION
This isn’t needed. Not sure how they got introduced (the UI doesn't seem to add this implicitly, and I don't know even know where the name `main` comes from within DuckDB).

Either way, removing these cleans up the output SQL on our examples (they continue to work).
I already did so for `sales` via the UI, and the Hashquery example on hashquery.dev automatically adjusted to no longer qualify the schema.